### PR TITLE
In-memory caching for event readers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,104 @@
+[*.cs]
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+
+#Formatting - new line options
+
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require members of anonymous types to be on the same line
+csharp_new_line_before_members_in_anonymous_types = false
+#require braces to be on a new line for types, methods, and control_blocks (also known as "Allman" style)
+csharp_new_line_before_open_brace = types, methods, control_blocks
+
+#Formatting - organize using options
+
+#do not place System.* using directives before other using directives
+dotnet_sort_system_directives_first = false
+
+#Formatting - spacing options
+
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+
+#Style - Code block preferences
+
+#prefer curly braces even for one line of code
+csharp_prefer_braces = true:suggestion
+
+#Style - expression bodied member options
+
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:suggestion
+#prefer expression-bodied members for properties
+csharp_style_expression_bodied_properties = true:suggestion
+
+#Style - expression level options
+
+#prefer out variables to be declared inline in the argument list of a method call when possible
+csharp_style_inlined_variable_declaration = true:suggestion
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+#prefer objects to be initialized using object initializers when possible
+dotnet_style_object_initializer = true:suggestion
+#prefer inferred anonymous type member names
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+
+#Style - implicit and explicit types
+
+#prefer var over explicit type in all cases, unless overridden by another code style rule
+csharp_style_var_elsewhere = true:suggestion
+#prefer var is used to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = true:suggestion
+#prefer var when the type is already mentioned on the right-hand side of a declaration expression
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - modifier options
+
+#prefer accessibility modifiers to be declared except for public interface members. This will currently not differ from always and will act as future proofing for if C# adds default interface methods.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+#when this rule is set to a list of modifiers, prefer the specified ordering.
+csharp_preferred_modifier_order = public,private,internal,static,async,readonly:suggestion
+
+#Style - qualification options
+
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods to be prefaced with this. in C# or Me. in Visual Basic
+dotnet_style_qualification_for_method = true:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/EventFeed.sln
+++ b/EventFeed.sln
@@ -33,6 +33,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFeed.AspNet.Tests.Inte
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "EventFeed.Producer.Caching", "src\EventFeed.Producer.Caching\EventFeed.Producer.Caching.fsproj", "{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{007927C5-8DA2-4379-A6FA-ED9060A11429}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "EventFeed.Producer.Caching.Tests.Unit", "test\building\EventFeed.Producer.Caching.Tests.Unit\EventFeed.Producer.Caching.Tests.Unit.fsproj", "{A0DED6E2-E687-4721-AE4E-FFBC2331A102}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +146,18 @@ Global
 		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x64.Build.0 = Release|Any CPU
 		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x86.ActiveCfg = Release|Any CPU
 		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x86.Build.0 = Release|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Debug|x64.Build.0 = Debug|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Debug|x86.Build.0 = Debug|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Release|x64.ActiveCfg = Release|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Release|x64.Build.0 = Release|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Release|x86.ActiveCfg = Release|Any CPU
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +175,7 @@ Global
 		{E8F392A5-8EE4-4F07-8CFA-66A7F6722F1F} = {0A39541F-22F9-4C93-AD70-E2107160BCA9}
 		{55A22490-871E-4FA8-8445-C220039C0264} = {46672673-3CFB-4427-8768-55C53A67D70B}
 		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F} = {55F7DA4A-F2BD-4AA1-BAC9-44BFD3A0F1FA}
+		{A0DED6E2-E687-4721-AE4E-FFBC2331A102} = {732B92C0-1F1F-4E61-B819-C1C6F0337E86}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ACE5B101-1C4B-4CD7-B6E4-EFC298AAC681}

--- a/EventFeed.sln
+++ b/EventFeed.sln
@@ -27,9 +27,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFeed.AspNetCore", "src
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "service-collection-example", "service-collection-example", "{0A39541F-22F9-4C93-AD70-E2107160BCA9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFeed.Example1.Api", "examples\service-collection-example\EventFeed.Example1.Api\EventFeed.Example1.Api.csproj", "{E8F392A5-8EE4-4F07-8CFA-66A7F6722F1F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFeed.Example1.Api", "examples\service-collection-example\EventFeed.Example1.Api\EventFeed.Example1.Api.csproj", "{E8F392A5-8EE4-4F07-8CFA-66A7F6722F1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFeed.AspNet.Tests.Integration", "test\communication\EventFeed.AspNet.Tests.Integration\EventFeed.AspNet.Tests.Integration.csproj", "{55A22490-871E-4FA8-8445-C220039C0264}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFeed.AspNet.Tests.Integration", "test\communication\EventFeed.AspNet.Tests.Integration\EventFeed.AspNet.Tests.Integration.csproj", "{55A22490-871E-4FA8-8445-C220039C0264}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "EventFeed.Producer.Caching", "src\EventFeed.Producer.Caching\EventFeed.Producer.Caching.fsproj", "{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -125,6 +127,18 @@ Global
 		{55A22490-871E-4FA8-8445-C220039C0264}.Release|x64.Build.0 = Release|Any CPU
 		{55A22490-871E-4FA8-8445-C220039C0264}.Release|x86.ActiveCfg = Release|Any CPU
 		{55A22490-871E-4FA8-8445-C220039C0264}.Release|x86.Build.0 = Release|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Debug|x64.Build.0 = Debug|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Debug|x86.Build.0 = Debug|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x64.ActiveCfg = Release|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x64.Build.0 = Release|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x86.ActiveCfg = Release|Any CPU
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,6 +155,7 @@ Global
 		{0A39541F-22F9-4C93-AD70-E2107160BCA9} = {B80375BB-C008-435D-A577-66929227405F}
 		{E8F392A5-8EE4-4F07-8CFA-66A7F6722F1F} = {0A39541F-22F9-4C93-AD70-E2107160BCA9}
 		{55A22490-871E-4FA8-8445-C220039C0264} = {46672673-3CFB-4427-8768-55C53A67D70B}
+		{40DBC8E2-4489-45EC-B80C-C35DA9A3F97F} = {55F7DA4A-F2BD-4AA1-BAC9-44BFD3A0F1FA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ACE5B101-1C4B-4CD7-B6E4-EFC298AAC681}

--- a/examples/service-collection-example/EventFeed.Example1.Api/Program.cs
+++ b/examples/service-collection-example/EventFeed.Example1.Api/Program.cs
@@ -1,6 +1,6 @@
 using EventFeed.AspNetCore;
 using EventFeed.Example1.Api;
-using EventFeed.MSSQL;
+using EventFeed.Producer.MSSQL;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +11,7 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-builder.Services.AddEventFeed(_ => new MSSQLEventFeedReader(config.GetConnectionString("Data")));
+builder.Services.AddEventFeed(options => options.AddSqlServer(config.GetConnectionString("Data")));
 builder.Services.AddTransient<TemperatureData>(c => new TemperatureData(config.GetConnectionString("Data")));
 
 var app = builder.Build();

--- a/src/EventFeed.AspNetCore/EventFeed.AspNetCore.csproj
+++ b/src/EventFeed.AspNetCore/EventFeed.AspNetCore.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EventFeed.Producer.Caching\EventFeed.Producer.Caching.fsproj" />
     <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
   </ItemGroup>
 

--- a/src/EventFeed.AspNetCore/EventFeedMiddleware.cs
+++ b/src/EventFeed.AspNetCore/EventFeedMiddleware.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Http;
 using EventFeed.Producer.Abstractions;
 using System.Text.Json.Serialization;
 using EventFeed.AspNetCore.Serialization;
 
-namespace EventFeed.AspNetCore
-{
+namespace EventFeed.AspNetCore {
     public class MetaLinks
     {
         public MetaLinks(string meta, string head, string tail)
@@ -269,24 +266,6 @@ namespace EventFeed.AspNetCore
         private static bool IsGetRequest(HttpContext context)
         {
             return context?.Request.Method.ToUpper() == "GET";
-        }
-    }
-
-    public static class EventFeedMiddlewareExtensions
-    {
-        public static IApplicationBuilder UseEventFeed(this IApplicationBuilder builder)
-        {
-            return builder.UseMiddleware<EventFeedMiddleware>();
-        }
-    }
-
-    public static class EventFeedServicesExtensions
-    {
-        public static IServiceCollection AddEventFeed(this IServiceCollection serviceCollection, Func<IServiceProvider, IEventFeedReader> factory)
-        {
-            serviceCollection.AddTransient(factory);
-            serviceCollection.AddTransient<EventFeedMiddleware>();
-            return serviceCollection;
         }
     }
 }

--- a/src/EventFeed.AspNetCore/EventFeedMiddlewareExtensions.cs
+++ b/src/EventFeed.AspNetCore/EventFeedMiddlewareExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace EventFeed.AspNetCore
+{
+    public static class EventFeedMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseEventFeed(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<EventFeedMiddleware>();
+        }
+    }
+}

--- a/src/EventFeed.AspNetCore/EventFeedOptions.cs
+++ b/src/EventFeed.AspNetCore/EventFeedOptions.cs
@@ -4,8 +4,10 @@ namespace EventFeed.AspNetCore
 {
     public class EventFeedOptions
     {
-        public bool UseCaching { get; set; } = true;
-        public int EventsPerPage { get; set; } = 100;
         public IEventFeedReader? EventFeedReader { get; set; }
+        public int EventsPerPage { get; set; } = 100;
+        public bool CacheEnabled { get; set; } = true;
+        public TimeSpan CacheCompletePageExpirationTime = TimeSpan.FromMinutes(5);
+        public TimeSpan CacheLastPageExpirationTime = TimeSpan.FromSeconds(1);
     }
 }

--- a/src/EventFeed.AspNetCore/EventFeedOptions.cs
+++ b/src/EventFeed.AspNetCore/EventFeedOptions.cs
@@ -1,0 +1,11 @@
+﻿using EventFeed.Producer.Abstractions;
+
+namespace EventFeed.AspNetCore
+{
+    public class EventFeedOptions
+    {
+        public bool UseCaching { get; set; } = true;
+        public int EventsPerPage { get; set; } = 100;
+        public IEventFeedReader? EventFeedReader { get; set; }
+    }
+}

--- a/src/EventFeed.AspNetCore/EventFeedOptionsBuilder.cs
+++ b/src/EventFeed.AspNetCore/EventFeedOptionsBuilder.cs
@@ -1,0 +1,21 @@
+﻿using EventFeed.Producer.Abstractions;
+
+namespace EventFeed.AspNetCore
+{
+    public class EventFeedOptionsBuilder
+    {
+        public EventFeedOptions Options { get; set; } = new EventFeedOptions();
+
+        public EventFeedOptionsBuilder UseReader(IEventFeedReader eventFeedReader)
+        {
+            Options.EventFeedReader = eventFeedReader;
+            return this;
+        }
+
+        public EventFeedOptionsBuilder UseCaching(bool value)
+        {
+            Options.UseCaching = value;
+            return this;
+        }
+    }
+}

--- a/src/EventFeed.AspNetCore/EventFeedOptionsBuilder.cs
+++ b/src/EventFeed.AspNetCore/EventFeedOptionsBuilder.cs
@@ -12,9 +12,9 @@ namespace EventFeed.AspNetCore
             return this;
         }
 
-        public EventFeedOptionsBuilder UseCaching(bool value)
+        public EventFeedOptionsBuilder UseCaching(bool enabled)
         {
-            Options.UseCaching = value;
+            Options.CacheEnabled = enabled;
             return this;
         }
     }

--- a/src/EventFeed.AspNetCore/EventFeedServicesExtensions.cs
+++ b/src/EventFeed.AspNetCore/EventFeedServicesExtensions.cs
@@ -1,0 +1,30 @@
+﻿using EventFeed.Producer.Caching;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventFeed.AspNetCore
+{
+    public static class EventFeedServicesExtensions
+    {
+        public static IServiceCollection AddEventFeed(this IServiceCollection serviceCollection, Action<EventFeedOptionsBuilder> optionsBuilder)
+        {
+            var builder = new EventFeedOptionsBuilder();
+            var options = builder.Options;
+            optionsBuilder.Invoke(builder);
+
+            if (options.UseCaching)
+            {
+                // wrap the EventFeedReader in a caching layer
+                serviceCollection.AddTransient((provider) => new CachingEventFeedReader(options.EventFeedReader, provider.GetService<IMemoryCache>()));
+            }
+            else
+            {
+                serviceCollection.AddTransient(x => options.EventFeedReader);
+            }
+
+            serviceCollection.AddTransient<EventFeedMiddleware>();
+
+            return serviceCollection;
+        }
+    }
+}

--- a/src/EventFeed.AspNetCore/EventFeedServicesExtensions.cs
+++ b/src/EventFeed.AspNetCore/EventFeedServicesExtensions.cs
@@ -12,10 +12,15 @@ namespace EventFeed.AspNetCore
             var options = builder.Options;
             optionsBuilder.Invoke(builder);
 
-            if (options.UseCaching)
+            if (options.CacheEnabled)
             {
                 // wrap the EventFeedReader in a caching layer
-                serviceCollection.AddTransient((provider) => new CachingEventFeedReader(options.EventFeedReader, provider.GetService<IMemoryCache>()));
+                serviceCollection.AddTransient((provider) => new CachingEventFeedReader(
+                    options.EventFeedReader,
+                    provider.GetService<IMemoryCache>(),
+                    options.CacheCompletePageExpirationTime,
+                    options.CacheLastPageExpirationTime
+                ));
             }
             else
             {

--- a/src/EventFeed.AspNetCore/EventFeedServicesExtensions.cs
+++ b/src/EventFeed.AspNetCore/EventFeedServicesExtensions.cs
@@ -1,4 +1,5 @@
-﻿using EventFeed.Producer.Caching;
+﻿using EventFeed.Producer.Abstractions;
+using EventFeed.Producer.Caching;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,9 +16,9 @@ namespace EventFeed.AspNetCore
             if (options.CacheEnabled)
             {
                 // wrap the EventFeedReader in a caching layer
-                serviceCollection.AddTransient((provider) => new CachingEventFeedReader(
+                serviceCollection.AddTransient<IEventFeedReader>((provider) => new CachingEventFeedReader(
                     options.EventFeedReader,
-                    provider.GetService<IMemoryCache>(),
+                    provider.GetRequiredService<IMemoryCache>(),
                     options.CacheCompletePageExpirationTime,
                     options.CacheLastPageExpirationTime
                 ));

--- a/src/EventFeed.Producer.Caching/CachingEventFeedReader.fs
+++ b/src/EventFeed.Producer.Caching/CachingEventFeedReader.fs
@@ -6,10 +6,8 @@ open Microsoft.Extensions.Caching.Memory
 open System
 
 /// Provides an in-memory caching layer that wraps an IEventFeedReader
-type CachingEventFeedReader(innerReader : IEventFeedReader, cache : IMemoryCache) =
-    static let completePageExpirationTime = TimeSpan.FromMinutes(5)
-    static let lastPageExpirationTime = TimeSpan.FromSeconds(1)
-    
+type CachingEventFeedReader(innerReader : IEventFeedReader, cache : IMemoryCache, completePageExpirationTime : TimeSpan, lastPageExpirationTime : TimeSpan) =
+
     let isLastPage (pageNumber : int) =
         let eventNumbers = innerReader.EventNumbers()
         let totalPages = Paging.totalPages eventNumbers.EventCount eventNumbers.EventsPerPage
@@ -20,6 +18,8 @@ type CachingEventFeedReader(innerReader : IEventFeedReader, cache : IMemoryCache
         | true ->  new MemoryCacheEntryOptions(AbsoluteExpirationRelativeToNow = lastPageExpirationTime)
         // Would be nice if we can use Size here so completed pages only get evicted when cache reaches max size
         | false -> new MemoryCacheEntryOptions(AbsoluteExpirationRelativeToNow = completePageExpirationTime )
+
+    new(innerReader : IEventFeedReader, cache : IMemoryCache) = new CachingEventFeedReader(innerReader, cache, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(1))
 
     interface IEventFeedReader with
 

--- a/src/EventFeed.Producer.Caching/CachingEventFeedReader.fs
+++ b/src/EventFeed.Producer.Caching/CachingEventFeedReader.fs
@@ -1,0 +1,36 @@
+﻿namespace EventFeed.Producer.Caching
+
+open EventFeed
+open EventFeed.Producer.Abstractions
+open Microsoft.Extensions.Caching.Memory
+open System
+
+/// Provides an in-memory caching layer that wraps an IEventFeedReader
+type CachingEventFeedReader(underlyingReader : IEventFeedReader, cache : IMemoryCache) =
+    static let completePageExpirationTime = TimeSpan.FromMinutes(5)
+    static let lastPageExpirationTime = TimeSpan.FromSeconds(1)
+    
+    let isLastPage (pageNumber : int) =
+        let eventNumbers = underlyingReader.EventNumbers()
+        let totalPages = Paging.totalPages eventNumbers.EventCount eventNumbers.EventsPerPage
+        pageNumber = totalPages
+
+    let getCacheEntryOptions (pageNumber : int) =
+        match isLastPage(pageNumber) with
+        | true ->  new MemoryCacheEntryOptions(AbsoluteExpirationRelativeToNow = lastPageExpirationTime)
+        // Would be nice if we can use Size here so completed pages only get evicted when cache reaches max size
+        | false -> new MemoryCacheEntryOptions(AbsoluteExpirationRelativeToNow = completePageExpirationTime )
+
+    interface IEventFeedReader with
+
+        member this.EventNumbers() = underlyingReader.EventNumbers()
+
+        member this.ReadPage pageNumber =
+            match cache.Get(pageNumber) with
+            | :? seq<FeedEvent> as entry -> entry
+            | null ->
+                let page = underlyingReader.ReadPage(pageNumber)
+                cache.Set(pageNumber, page, getCacheEntryOptions(pageNumber))
+            | _ -> failwith("Unexpected cache response")
+
+        member this.Dispose() = underlyingReader.Dispose()

--- a/src/EventFeed.Producer.Caching/EventFeed.Producer.Caching.fsproj
+++ b/src/EventFeed.Producer.Caching/EventFeed.Producer.Caching.fsproj
@@ -10,11 +10,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
+        <PackageReference Update="FSharp.Core" Version="6.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
+        <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
     </ItemGroup>
 
 </Project>

--- a/src/EventFeed.Producer.Caching/EventFeed.Producer.Caching.fsproj
+++ b/src/EventFeed.Producer.Caching/EventFeed.Producer.Caching.fsproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="CachingEventFeedReader.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
+++ b/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="Events.fs" />
     <Compile Include="MSSQLEventFeedReader.fs" />
+    <Compile Include="EventFeedOptionsBuilderExtensions.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EventFeed.AspNetCore\EventFeed.AspNetCore.csproj" />
     <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
   </ItemGroup>
 

--- a/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
+++ b/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
@@ -1,40 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.0.0-alpha</Version>
-		<Authors>Devon Burriss;Robert Massa</Authors>
-		<Copyright>Devon Burriss 2022</Copyright>
-		<PackageTags>messaging;persistent;mssql</PackageTags>
-		<PackageId>EventFeed.Producer.MSSQL</PackageId>
-		<Title>EventFeed Producer persistence for MS-SQL</Title>
-		<Description>Allows easy persistence of events within a transation to a MS-SQL database. EventFeed allows the publishing of messages to a database in a transaction, avoiding the dual-write problem. The persistent event feed can then be consumed via a HTTP endpoint.</Description>
-		<RepositoryUrl>https://github.com/dburriss/event-feed/</RepositoryUrl>
-	</PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <Version>0.0.0-alpha</Version>
+        <Authors>Devon Burriss;Robert Massa</Authors>
+        <Copyright>Devon Burriss 2022</Copyright>
+        <PackageTags>messaging;persistent;mssql</PackageTags>
+        <PackageId>EventFeed.Producer.MSSQL</PackageId>
+        <Title>EventFeed Producer persistence for MS-SQL</Title>
+        <Description>Allows easy persistence of events within a transation to a MS-SQL database. EventFeed allows the publishing of messages to a database in a transaction, avoiding the dual-write problem. The persistent event feed can then be consumed via a HTTP endpoint.</Description>
+        <RepositoryUrl>https://github.com/dburriss/event-feed/</RepositoryUrl>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="Events.fs" />
-    <Compile Include="MSSQLEventFeedReader.fs" />
-    <Compile Include="EventFeedOptionsBuilderExtensions.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Events.fs" />
+        <Compile Include="MSSQLEventFeedReader.fs" />
+        <Compile Include="EventFeedOptionsBuilderExtensions.fs" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+        <PackageReference Update="FSharp.Core" Version="6.0.3" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\EventFeed.AspNetCore\EventFeed.AspNetCore.csproj" />
-    <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
-  </ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="6.0.3" />
-	</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\EventFeed.AspNetCore\EventFeed.AspNetCore.csproj" />
+        <ProjectReference Include="..\EventFeed\EventFeed.fsproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/EventFeed.Producer.MSSQL/EventFeedOptionsBuilderExtensions.fs
+++ b/src/EventFeed.Producer.MSSQL/EventFeedOptionsBuilderExtensions.fs
@@ -1,0 +1,10 @@
+﻿namespace EventFeed.Producer.MSSQL
+
+open System.Runtime.CompilerServices
+open EventFeed.AspNetCore
+
+[<Extension>]
+type EventFeedOptionsBuilderExtensions =
+    [<Extension>]
+    static member inline AddSqlServer(optionsBuilder: EventFeedOptionsBuilder, connectionString: string) =
+        optionsBuilder.UseReader(new MSSQLEventFeedReader(connectionString, optionsBuilder.Options.EventsPerPage))

--- a/src/EventFeed.Producer.MSSQL/MSSQLEventFeedReader.fs
+++ b/src/EventFeed.Producer.MSSQL/MSSQLEventFeedReader.fs
@@ -1,9 +1,8 @@
-﻿namespace EventFeed.MSSQL
+﻿namespace EventFeed.Producer.MSSQL
 
 open EventFeed.Producer.Abstractions
 open Microsoft.Data.SqlClient
 open System.Runtime.InteropServices
-open EventFeed.Producer.MSSQL
 open System.Data.Common
 open System.Data
 

--- a/test/building/EventFeed.Producer.Caching.Tests.Unit/EventFeed.Producer.Caching.Tests.Unit.fsproj
+++ b/test/building/EventFeed.Producer.Caching.Tests.Unit/EventFeed.Producer.Caching.Tests.Unit.fsproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+        <GenerateProgramFile>false</GenerateProgramFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Tests.fs" />
+        <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\EventFeed.Producer.Caching\EventFeed.Producer.Caching.fsproj" />
+        <ProjectReference Include="..\..\..\src\EventFeed\EventFeed.fsproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="6.0.4" />
+    </ItemGroup>
+
+</Project>

--- a/test/building/EventFeed.Producer.Caching.Tests.Unit/Program.fs
+++ b/test/building/EventFeed.Producer.Caching.Tests.Unit/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/test/building/EventFeed.Producer.Caching.Tests.Unit/Tests.fs
+++ b/test/building/EventFeed.Producer.Caching.Tests.Unit/Tests.fs
@@ -1,0 +1,74 @@
+namespace EventFeed.Producer.Caching.Tests.Unit
+
+open EventFeed
+open EventFeed.Producer.Abstractions
+open System
+
+type InMemoryEventFeedReader(eventCount : int, eventsPerPage : int) =
+    let createFeedEvent sequenceNumber = {
+            EventId = Guid.NewGuid()
+            EventName = "FakeEvent"
+            EventSchemaVersion = 1s
+            Payload = ""
+            SequenceNumber = sequenceNumber
+            SpanId = Telemetry.getTraceId().ToString()
+            CreatedAt = (DateTimeOffset.UtcNow)
+            TraceId = Telemetry.getTraceId().ToString()
+        }
+
+    let events = [ for i in 1 .. eventCount -> createFeedEvent i ]
+    
+    let mutable readPageCallCount = 0
+    member this.ReadPageCallCount = readPageCallCount
+
+    interface IEventFeedReader with
+        member this.EventNumbers() = {
+            EventCount = eventCount
+            EventsPerPage = eventsPerPage
+        }
+
+        member this.ReadPage pageNumber = 
+            readPageCallCount <- readPageCallCount + 1
+            let startIndex = pageNumber * eventsPerPage
+            let endIndex = startIndex + eventsPerPage - 1
+            events[startIndex..endIndex]
+
+        member this.Dispose() = ()
+
+module LibraryTests =
+    open Xunit
+    open EventFeed.Producer.Caching
+    open Microsoft.Extensions.Caching.Memory
+
+    [<Fact>]
+    let ``Returns uncached page from inner reader`` () =
+        let cache = new MemoryCache(new MemoryCacheOptions())
+        let innerReader = new InMemoryEventFeedReader(eventCount = 25, eventsPerPage = 5)
+        let cachingReader = new CachingEventFeedReader(innerReader, cache) :> IEventFeedReader
+        
+        cachingReader.ReadPage(1) |> ignore
+
+        Assert.Equal(1, innerReader.ReadPageCallCount)
+
+    [<Fact>]
+    let ``Returns cached page without calling inner reader`` () =
+        let cache = new MemoryCache(new MemoryCacheOptions())
+        let innerReader = new InMemoryEventFeedReader(eventCount = 25, eventsPerPage = 5)
+        let cachingReader = new CachingEventFeedReader(innerReader, cache) :> IEventFeedReader
+        
+        cachingReader.ReadPage(1) |> ignore
+        cachingReader.ReadPage(1) |> ignore
+
+        Assert.Equal(1, innerReader.ReadPageCallCount)
+
+    [<Fact>]
+    let ``Returns the same page for cached and non-cached`` () =
+        let cache = new MemoryCache(new MemoryCacheOptions())
+        let innerReader = new InMemoryEventFeedReader(eventCount = 25, eventsPerPage = 5)
+        let cachingReader = new CachingEventFeedReader(innerReader, cache) :> IEventFeedReader
+        
+        let uncachedPage = cachingReader.ReadPage(1) |> ignore
+        let cachedPage = cachingReader.ReadPage(1) |> ignore
+
+        Assert.Equal(1, innerReader.ReadPageCallCount)
+        Assert.Equal(uncachedPage, cachedPage)


### PR DESCRIPTION
Initial draft for an in-memory caching layer that wraps an IEventFeedReader based on https://github.com/dburriss/event-feed/issues/2.

Some considerations:

- Complete pages now still expire within an absolute expiration time. It would be nicer if we could allocate a fixed size memory budget to keep pages in memory as long as we're within budget but this seems tricky as calculating object memory usage is required to set the `Size` property on `MemoryCacheEntryOptions`. A possible solution would be to estimate this based on the payload size.
- Usage-metrics are kept out of scope but this impl. should not prevent that.
- No worker-based cache refreshing is done, see https://github.com/dburriss/event-feed/issues/2#issuecomment-1092052140.
- F# might not be idiomatic, feedback appreciated!

Further work:

- Tests + docs
- ASP.NET Core helpers to easily add this.
- Make expiration options configurable.
- Support new event notification and update the in-memory cache.
- Possibly abstract the IMemoryCache to support distributed caching scenarios (seems like this can be done when actually required).
- Discuss back-channel notifications (needs more information).