### PR TITLE
Feature/add nuget package dotnet core support

### DIFF
--- a/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
+++ b/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.0.0-alpha</Version>
+		<Version>0.0.1-alpha</Version>
 		<Authors>Devon Burriss;Robert Massa</Authors>
 		<Copyright>Devon Burriss 2022</Copyright>
 		<PackageTags>messaging;persistent;mssql</PackageTags>

--- a/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
+++ b/src/EventFeed.Producer.MSSQL/EventFeed.Producer.MSSQL.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<Version>0.0.0-alpha</Version>
@@ -12,6 +11,7 @@
 		<Title>EventFeed Producer persistence for MS-SQL</Title>
 		<Description>Allows easy persistence of events within a transation to a MS-SQL database. EventFeed allows the publishing of messages to a database in a transaction, avoiding the dual-write problem. The persistent event feed can then be consumed via a HTTP endpoint.</Description>
 		<RepositoryUrl>https://github.com/dburriss/event-feed/</RepositoryUrl>
+		<TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/EventFeed/EventFeed.fsproj
+++ b/src/EventFeed/EventFeed.fsproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.0.0-alpha</Version>
+		<Version>0.0.1-alpha</Version>
 		<Authors>Devon Burriss;Robert Massa</Authors>
 		<Copyright>Devon Burriss 2022</Copyright>
 		<PackageTags>messaging;persistent</PackageTags>

--- a/src/EventFeed/EventFeed.fsproj
+++ b/src/EventFeed/EventFeed.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<Version>0.0.0-alpha</Version>
@@ -12,6 +11,7 @@
 		<Title>Event Feed</Title>
 		<Description>The core types and abstractions for the EventFeed messaging functionality. EventFeed allows the publishing of messages to a database in a transaction, avoiding the dual-write problem. The persistent event feed can then be consumed via a HTTP endpoint.</Description>
 		<RepositoryUrl>https://github.com/dburriss/event-feed/</RepositoryUrl>
+		<TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Our applications still work with .net core 3.1 and we want to make use of the MSSQL producer and therefor I added the targeting frameworks to those libs.

The issue with also having .net core 3.1 for the ASP.NET Core page is that the JSON serialization contexts are only available for .net 6 at the moment. I either need to rewrite them specifically for .net core 3.1 or I can add the 3.1 only to core and MSSQL package.
If you have a better suggestion or you want the rewrite, then please let me know.